### PR TITLE
Option to disable async pattern added to Web activity

### DIFF
--- a/ADFv2/ProcessAzureAS MSI.json
+++ b/ADFv2/ProcessAzureAS MSI.json
@@ -7,7 +7,7 @@
                 "type": "Until",
                 "dependsOn": [
                     {
-                        "activity": "FilterToCurrentRefresh",
+                        "activity": "StartProcessingAzureAS",
                         "dependencyConditions": [
                             "Succeeded"
                         ]
@@ -39,11 +39,15 @@
                             },
                             "userProperties": [],
                             "typeProperties": {
+                                "method": "GET",
                                 "url": {
-                                    "value": "@concat('https://',pipeline().parameters.Region,'.asazure.windows.net/servers/',pipeline().parameters.Server,'/models/',pipeline().parameters.DatabaseName,'/refreshes/',activity('FilterToCurrentRefresh').output.Value[0].refreshId)",
+                                    "value": "@activity('StartProcessingAzureAS').output.ADFWebActivityResponseHeaders.Location",
                                     "type": "Expression"
                                 },
-                                "method": "GET",
+                                "connectVia": {
+                                    "referenceName": "AutoResolveIntegrationRuntime",
+                                    "type": "IntegrationRuntimeReference"
+                                },
                                 "authentication": {
                                     "type": "MSI",
                                     "resource": "https://*.asazure.windows.net"
@@ -75,11 +79,16 @@
                 },
                 "userProperties": [],
                 "typeProperties": {
+                    "method": "POST",
+                    "turnOffAsync": true,
                     "url": {
                         "value": "@concat('https://',pipeline().parameters.Region,'.asazure.windows.net/servers/',pipeline().parameters.Server,'/models/',pipeline().parameters.DatabaseName,'/refreshes')",
                         "type": "Expression"
                     },
-                    "method": "POST",
+                    "connectVia": {
+                        "referenceName": "AutoResolveIntegrationRuntime",
+                        "type": "IntegrationRuntimeReference"
+                    },
                     "body": {
                         "Type": "Full",
                         "CommitMode": "transactional",
@@ -124,69 +133,6 @@
                             }
                         }
                     ]
-                }
-            },
-            {
-                "name": "GetAzureASRefreshes",
-                "type": "WebActivity",
-                "dependsOn": [
-                    {
-                        "activity": "StartProcessingAzureAS",
-                        "dependencyConditions": [
-                            "Succeeded"
-                        ]
-                    }
-                ],
-                "policy": {
-                    "timeout": "7.00:00:00",
-                    "retry": 0,
-                    "retryIntervalInSeconds": 30,
-                    "secureOutput": false
-                },
-                "userProperties": [],
-                "typeProperties": {
-                    "url": {
-                        "value": "@concat('https://',pipeline().parameters.Region,'.asazure.windows.net/servers/',pipeline().parameters.Server,'/models/',pipeline().parameters.DatabaseName,'/refreshes')",
-                        "type": "Expression"
-                    },
-                    "connectVia": {
-                        "referenceName": "AutoResolveIntegrationRuntime",
-                        "type": "IntegrationRuntimeReference"
-                    },
-                    "method": "GET",
-                    "body": {
-                        "Type": "Full",
-                        "CommitMode": "transactional",
-                        "MaxParallelism": 10,
-                        "RetryCount": 2
-                    },
-                    "authentication": {
-                        "type": "MSI",
-                        "resource": "https://*.asazure.windows.net"
-                    }
-                }
-            },
-            {
-                "name": "FilterToCurrentRefresh",
-                "type": "Filter",
-                "dependsOn": [
-                    {
-                        "activity": "GetAzureASRefreshes",
-                        "dependencyConditions": [
-                            "Succeeded"
-                        ]
-                    }
-                ],
-                "userProperties": [],
-                "typeProperties": {
-                    "items": {
-                        "value": "@json(activity('GetAzureASRefreshes').output.Response)",
-                        "type": "Expression"
-                    },
-                    "condition": {
-                        "value": "@greaterOrEquals(item().startTime,addseconds(activity('StartProcessingAzureAS').output.startTime,-30))",
-                        "type": "Expression"
-                    }
                 }
             }
         ],

--- a/ADFv2/ProcessAzureAS.json
+++ b/ADFv2/ProcessAzureAS.json
@@ -1,39 +1,13 @@
 {
-    "name": "ProcessAzureAS",
+    "name": "ProcessAzureAS MSI",
     "properties": {
         "activities": [
-            {
-                "name": "Login",
-                "type": "WebActivity",
-                "dependsOn": [],
-                "policy": {
-                    "timeout": "7.00:00:00",
-                    "retry": 0,
-                    "retryIntervalInSeconds": 30,
-                    "secureOutput": false
-                },
-                "userProperties": [],
-                "typeProperties": {
-                    "url": {
-                        "value": "@concat('https://login.microsoftonline.com/',pipeline().parameters.TenantID,'/oauth2/token')",
-                        "type": "Expression"
-                    },
-                    "method": "POST",
-                    "headers": {
-                        "Content-Type": "application/x-www-form-urlencoded"
-                    },
-                    "body": {
-                        "value": "@concat('grant_type=client_credentials&resource=https://*.asazure.windows.net&client_id=',pipeline().parameters.ClientID,'&client_secret=',encodeUriComponent(pipeline().parameters.ClientSecret))",
-                        "type": "Expression"
-                    }
-                }
-            },
             {
                 "name": "UntilRefreshComplete",
                 "type": "Until",
                 "dependsOn": [
                     {
-                        "activity": "FilterToCurrentRefresh",
+                        "activity": "StartProcessingAzureAS",
                         "dependencyConditions": [
                             "Succeeded"
                         ]
@@ -65,16 +39,18 @@
                             },
                             "userProperties": [],
                             "typeProperties": {
+                                "method": "GET",
                                 "url": {
-                                    "value": "@concat('https://',pipeline().parameters.Region,'.asazure.windows.net/servers/',pipeline().parameters.Server,'/models/',pipeline().parameters.DatabaseName,'/refreshes/',activity('FilterToCurrentRefresh').output.Value[0].refreshId)",
+                                    "value": "@activity('StartProcessingAzureAS').output.ADFWebActivityResponseHeaders.Location",
                                     "type": "Expression"
                                 },
-                                "method": "GET",
-                                "headers": {
-                                    "Authorization": {
-                                        "value": "@concat(string(activity('Login').output.token_type),' ',string(activity('Login').output.access_token))",
-                                        "type": "Expression"
-                                    }
+                                "connectVia": {
+                                    "referenceName": "AutoResolveIntegrationRuntime",
+                                    "type": "IntegrationRuntimeReference"
+                                },
+                                "authentication": {
+                                    "type": "MSI",
+                                    "resource": "https://*.asazure.windows.net"
                                 }
                             }
                         },
@@ -92,39 +68,9 @@
                 }
             },
             {
-                "name": "FilterToCurrentRefresh",
-                "type": "Filter",
-                "dependsOn": [
-                    {
-                        "activity": "GetAzureASRefreshes",
-                        "dependencyConditions": [
-                            "Succeeded"
-                        ]
-                    }
-                ],
-                "userProperties": [],
-                "typeProperties": {
-                    "items": {
-                        "value": "@json(activity('GetAzureASRefreshes').output.Response)",
-                        "type": "Expression"
-                    },
-                    "condition": {
-                        "value": "@greaterOrEquals(item().startTime,addseconds(activity('StartProcessingAzureAS').output.startTime,-30))",
-                        "type": "Expression"
-                    }
-                }
-            },
-            {
                 "name": "StartProcessingAzureAS",
                 "type": "WebActivity",
-                "dependsOn": [
-                    {
-                        "activity": "Login",
-                        "dependencyConditions": [
-                            "Succeeded"
-                        ]
-                    }
-                ],
+                "dependsOn": [],
                 "policy": {
                     "timeout": "7.00:00:00",
                     "retry": 0,
@@ -133,22 +79,25 @@
                 },
                 "userProperties": [],
                 "typeProperties": {
+                    "method": "POST",
+                    "turnOffAsync": true,
                     "url": {
                         "value": "@concat('https://',pipeline().parameters.Region,'.asazure.windows.net/servers/',pipeline().parameters.Server,'/models/',pipeline().parameters.DatabaseName,'/refreshes')",
                         "type": "Expression"
                     },
-                    "method": "POST",
-                    "headers": {
-                        "Authorization": {
-                            "value": "@concat(string(activity('Login').output.token_type),' ',string(activity('Login').output.access_token))",
-                            "type": "Expression"
-                        }
+                    "connectVia": {
+                        "referenceName": "AutoResolveIntegrationRuntime",
+                        "type": "IntegrationRuntimeReference"
                     },
                     "body": {
                         "Type": "Full",
                         "CommitMode": "transactional",
                         "MaxParallelism": 10,
                         "RetryCount": 2
+                    },
+                    "authentication": {
+                        "type": "MSI",
+                        "resource": "https://*.asazure.windows.net"
                     }
                 }
             },
@@ -176,60 +125,19 @@
                             "dependsOn": [],
                             "userProperties": [],
                             "typeProperties": {
-                                "message": "@string(activity('GetAzureASRefreshStatus').output)",
+                                "message": {
+                                    "value": "@string(activity('GetAzureASRefreshStatus').output)",
+                                    "type": "Expression"
+                                },
                                 "errorCode": "100"
                             }
                         }
                     ]
                 }
-            },
-            {
-                "name": "GetAzureASRefreshes",
-                "type": "WebActivity",
-                "dependsOn": [
-                    {
-                        "activity": "StartProcessingAzureAS",
-                        "dependencyConditions": [
-                            "Succeeded"
-                        ]
-                    }
-                ],
-                "policy": {
-                    "timeout": "7.00:00:00",
-                    "retry": 0,
-                    "retryIntervalInSeconds": 30,
-                    "secureOutput": false
-                },
-                "userProperties": [],
-                "typeProperties": {
-                    "url": {
-                        "value": "@concat('https://',pipeline().parameters.Region,'.asazure.windows.net/servers/',pipeline().parameters.Server,'/models/',pipeline().parameters.DatabaseName,'/refreshes')",
-                        "type": "Expression"
-                    },
-                    "method": "GET",
-                    "headers": {
-                        "Authorization": {
-                            "value": "@concat(string(activity('Login').output.token_type),' ',string(activity('Login').output.access_token))",
-                            "type": "Expression"
-                        }
-                    },
-                    "body": {
-                        "Type": "Full",
-                        "CommitMode": "transactional",
-                        "MaxParallelism": 10,
-                        "RetryCount": 2
-                    }
-                }
             }
         ],
         "parameters": {
             "TenantID": {
-                "type": "String"
-            },
-            "ClientID": {
-                "type": "String"
-            },
-            "ClientSecret": {
                 "type": "String"
             },
             "SubscriptionID": {

--- a/ADFv2/ProcessAzureAS.json
+++ b/ADFv2/ProcessAzureAS.json
@@ -3,11 +3,37 @@
     "properties": {
         "activities": [
             {
+                "name": "Login",
+                "type": "WebActivity",
+                "dependsOn": [],
+                "policy": {
+                    "timeout": "7.00:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "url": {
+                        "value": "@concat('https://login.microsoftonline.com/',pipeline().parameters.TenantID,'/oauth2/token')",
+                        "type": "Expression"
+                    },
+                    "method": "POST",
+                    "headers": {
+                        "Content-Type": "application/x-www-form-urlencoded"
+                    },
+                    "body": {
+                        "value": "@concat('grant_type=client_credentials&resource=https://*.asazure.windows.net&client_id=',pipeline().parameters.ClientID,'&client_secret=',encodeUriComponent(pipeline().parameters.ClientSecret))",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
                 "name": "UntilRefreshComplete",
                 "type": "Until",
                 "dependsOn": [
                     {
-                        "activity": "StartProcessingAzureAS",
+                        "activity": "FilterToCurrentRefresh",
                         "dependencyConditions": [
                             "Succeeded"
                         ]
@@ -39,18 +65,16 @@
                             },
                             "userProperties": [],
                             "typeProperties": {
-                                "method": "GET",
                                 "url": {
-                                    "value": "@activity('StartProcessingAzureAS').output.ADFWebActivityResponseHeaders.Location",
+                                    "value": "@concat('https://',pipeline().parameters.Region,'.asazure.windows.net/servers/',pipeline().parameters.Server,'/models/',pipeline().parameters.DatabaseName,'/refreshes/',activity('FilterToCurrentRefresh').output.Value[0].refreshId)",
                                     "type": "Expression"
                                 },
-                                "connectVia": {
-                                    "referenceName": "AutoResolveIntegrationRuntime",
-                                    "type": "IntegrationRuntimeReference"
-                                },
-                                "authentication": {
-                                    "type": "MSI",
-                                    "resource": "https://*.asazure.windows.net"
+                                "method": "GET",
+                                "headers": {
+                                    "Authorization": {
+                                        "value": "@concat(string(activity('Login').output.token_type),' ',string(activity('Login').output.access_token))",
+                                        "type": "Expression"
+                                    }
                                 }
                             }
                         },
@@ -68,9 +92,39 @@
                 }
             },
             {
+                "name": "FilterToCurrentRefresh",
+                "type": "Filter",
+                "dependsOn": [
+                    {
+                        "activity": "GetAzureASRefreshes",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "userProperties": [],
+                "typeProperties": {
+                    "items": {
+                        "value": "@json(activity('GetAzureASRefreshes').output.Response)",
+                        "type": "Expression"
+                    },
+                    "condition": {
+                        "value": "@greaterOrEquals(item().startTime,addseconds(activity('StartProcessingAzureAS').output.startTime,-30))",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
                 "name": "StartProcessingAzureAS",
                 "type": "WebActivity",
-                "dependsOn": [],
+                "dependsOn": [
+                    {
+                        "activity": "Login",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
                 "policy": {
                     "timeout": "7.00:00:00",
                     "retry": 0,
@@ -79,25 +133,22 @@
                 },
                 "userProperties": [],
                 "typeProperties": {
-                    "method": "POST",
-                    "turnOffAsync": true,
                     "url": {
                         "value": "@concat('https://',pipeline().parameters.Region,'.asazure.windows.net/servers/',pipeline().parameters.Server,'/models/',pipeline().parameters.DatabaseName,'/refreshes')",
                         "type": "Expression"
                     },
-                    "connectVia": {
-                        "referenceName": "AutoResolveIntegrationRuntime",
-                        "type": "IntegrationRuntimeReference"
+                    "method": "POST",
+                    "headers": {
+                        "Authorization": {
+                            "value": "@concat(string(activity('Login').output.token_type),' ',string(activity('Login').output.access_token))",
+                            "type": "Expression"
+                        }
                     },
                     "body": {
                         "Type": "Full",
                         "CommitMode": "transactional",
                         "MaxParallelism": 10,
                         "RetryCount": 2
-                    },
-                    "authentication": {
-                        "type": "MSI",
-                        "resource": "https://*.asazure.windows.net"
                     }
                 }
             },
@@ -125,19 +176,60 @@
                             "dependsOn": [],
                             "userProperties": [],
                             "typeProperties": {
-                                "message": {
-                                    "value": "@string(activity('GetAzureASRefreshStatus').output)",
-                                    "type": "Expression"
-                                },
+                                "message": "@string(activity('GetAzureASRefreshStatus').output)",
                                 "errorCode": "100"
                             }
                         }
                     ]
                 }
+            },
+            {
+                "name": "GetAzureASRefreshes",
+                "type": "WebActivity",
+                "dependsOn": [
+                    {
+                        "activity": "StartProcessingAzureAS",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "timeout": "7.00:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "url": {
+                        "value": "@concat('https://',pipeline().parameters.Region,'.asazure.windows.net/servers/',pipeline().parameters.Server,'/models/',pipeline().parameters.DatabaseName,'/refreshes')",
+                        "type": "Expression"
+                    },
+                    "method": "GET",
+                    "headers": {
+                        "Authorization": {
+                            "value": "@concat(string(activity('Login').output.token_type),' ',string(activity('Login').output.access_token))",
+                            "type": "Expression"
+                        }
+                    },
+                    "body": {
+                        "Type": "Full",
+                        "CommitMode": "transactional",
+                        "MaxParallelism": 10,
+                        "RetryCount": 2
+                    }
+                }
             }
         ],
         "parameters": {
             "TenantID": {
+                "type": "String"
+            },
+            "ClientID": {
+                "type": "String"
+            },
+            "ClientSecret": {
                 "type": "String"
             },
             "SubscriptionID": {

--- a/ADFv2/ProcessAzureAS.json
+++ b/ADFv2/ProcessAzureAS.json
@@ -1,5 +1,5 @@
 {
-    "name": "ProcessAzureAS MSI",
+    "name": "ProcessAzureAS",
     "properties": {
         "activities": [
             {


### PR DESCRIPTION
ADF web activity now as an option to disable async pattern which allows for using the Location (URL for retrieving the status of the refreshId associated with the POST call) from within the ADFWebActivityResponseHeaders of the StartProcessingAzureAS's response.

The Location can then be used as the URL for the GetAzureASRefreshStatus activity within the While loop as the URL. 

This eliminates the need for the GetAzureASRefreshes and FilterToCurrentRefresh activities and eliminates any complications if multiple refreshes had started within the last 30 seconds. (basically we always get the correct refreshId)

Reference:
https://techcommunity.microsoft.com/t5/azure-data-factory/adf-web-activity-missing-response-headers/m-p/2709492